### PR TITLE
[Image Modification] fixed cwebp degrades quality by default

### DIFF
--- a/extensions/sips/CHANGELOG.md
+++ b/extensions/sips/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Image Modification Changelog
 
+## [Webp Image Quality Fix] - 2024-06-15
+
+- Fixed an issue when converting to webp degrades the quality of the image
+
 ## [WebP Hotfix] - 2024-01-29
 
 - Fixed some commands (e.g. convert) looking for WebP binaries in the wrong location

--- a/extensions/sips/package.json
+++ b/extensions/sips/package.json
@@ -22,7 +22,8 @@
   "author": "HelloImSteven",
   "contributors": [
     "arronhunt",
-    "nakaakist"
+    "nakaakist",
+    "JUSTIVE"
   ],
   "categories": [
     "Media",

--- a/extensions/sips/src/operations/convertOperation.ts
+++ b/extensions/sips/src/operations/convertOperation.ts
@@ -57,7 +57,7 @@ export default async function convert(sourcePaths: string[], desiredType: string
     if (desiredType === "WEBP") {
       // Input Format -> WebP
       const [, cwebpPath] = await getWebPBinaryPath();
-      execSync(`${cwebpPath} "${item}" -o "${newPath}"`);
+      execSync(`${cwebpPath} "${item}" -lossless -o "${newPath}"`);
     } else if (originalType.toLowerCase() == "svg") {
       // SVG -> NSBitmapImageRep -> Desired Format
       convertSVG(desiredType, item, newPath);


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
